### PR TITLE
Changed macro to directly run command

### DIFF
--- a/ababot/Cargo.lock
+++ b/ababot/Cargo.lock
@@ -89,6 +89,7 @@ name = "bot"
 version = "0.1.0"
 dependencies = [
  "dir_macros",
+ "openssl",
  "rand",
  "serde",
  "serde_json",
@@ -786,6 +787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.22.0+1.1.1q"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +804,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/ababot/bot/Cargo.toml
+++ b/ababot/bot/Cargo.toml
@@ -16,3 +16,4 @@ rand = { version = "0.8", optional = true }
 serde = "1.0.0"
 serde_json = "1.0.0"
 yahoo_finance_api = "=1.2.2"
+openssl = { version = '0.10', features = ["vendored"] }

--- a/ababot/bot/src/commands/dice.rs
+++ b/ababot/bot/src/commands/dice.rs
@@ -1,20 +1,26 @@
 use serenity::{
     builder::CreateApplicationCommand,
     model::prelude::{
-        command::CommandOptionType, interaction::application_command::CommandDataOption,
+        command::{self, CommandOptionType},
+        interaction::application_command,
+        interaction::{
+            application_command::{ApplicationCommandInteraction, CommandDataOption},
+            InteractionResponseType,
+        },
     },
+    prelude::Context,
 };
 
 #[cfg(feature = "dice")]
 use rand::{thread_rng, Rng};
 
-pub async fn run(options: &[CommandDataOption]) -> String {
+pub async fn run(ctx: &Context, command: &ApplicationCommandInteraction) {
     #[cfg(feature = "dice")]
     {
         let mut min = 0;
         let mut max = 100;
 
-        for option in options {
+        for option in &command.data.options {
             if option.name == "min" {
                 min = option
                     .value
@@ -32,16 +38,30 @@ pub async fn run(options: &[CommandDataOption]) -> String {
                     .unwrap_or(100);
             }
         }
-        if min == max {
-            return format!("{} to {} is not a valid range", min, max);
-        } else if max < min {
+        let dice_roll;
+        if max < min {
             let tmp = max;
             max = min;
             min = tmp;
         }
-        let mut rng = thread_rng();
-        rng.gen_range(min..max).to_string()
+        if min == max {
+            dice_roll = format!("{} to {} is not a valid range", min, max);
+        } else {
+            let mut rng = thread_rng();
+            dice_roll = rng.gen_range(min..max).to_string();
+        }
+        if let Err(why) = command
+            .create_interaction_response(&ctx.http, |response| {
+                response
+                    .kind(InteractionResponseType::ChannelMessageWithSource)
+                    .interaction_response_data(|message| message.content(dice_roll))
+            })
+            .await
+        {
+            tracing::warn!("Failed to run command: {}", why);
+        }
     }
+    // Feature noe deprecated, fix before merge
     #[cfg(not(feature = "dice"))]
     {
         "Command disabled".to_string()

--- a/ababot/bot/src/commands/dice.rs
+++ b/ababot/bot/src/commands/dice.rs
@@ -1,11 +1,9 @@
 use serenity::{
     builder::CreateApplicationCommand,
     model::prelude::{
-        command::{self, CommandOptionType},
-        interaction::application_command,
+        command::CommandOptionType,
         interaction::{
-            application_command::{ApplicationCommandInteraction, CommandDataOption},
-            InteractionResponseType,
+            application_command::ApplicationCommandInteraction, InteractionResponseType,
         },
     },
     prelude::Context,

--- a/ababot/bot/src/commands/knock.rs
+++ b/ababot/bot/src/commands/knock.rs
@@ -1,8 +1,7 @@
 use serenity::{
     builder::CreateApplicationCommand,
     model::prelude::interaction::{
-        application_command::{ApplicationCommandInteraction, CommandDataOption},
-        InteractionResponseType,
+        application_command::ApplicationCommandInteraction, InteractionResponseType,
     },
     prelude::Context,
 };

--- a/ababot/bot/src/commands/knock.rs
+++ b/ababot/bot/src/commands/knock.rs
@@ -1,10 +1,24 @@
 use serenity::{
     builder::CreateApplicationCommand,
-    model::prelude::interaction::application_command::CommandDataOption,
+    model::prelude::interaction::{
+        application_command::{ApplicationCommandInteraction, CommandDataOption},
+        InteractionResponseType,
+    },
+    prelude::Context,
 };
 
-pub async fn run(_options: &[CommandDataOption]) -> String {
-    "Come in".to_string()
+pub async fn run(ctx: &Context, command: &ApplicationCommandInteraction) {
+    let ans = "Come in".to_string();
+    if let Err(why) = command
+        .create_interaction_response(&ctx.http, |response| {
+            response
+                .kind(InteractionResponseType::ChannelMessageWithSource)
+                .interaction_response_data(|message| message.content(ans))
+        })
+        .await
+    {
+        tracing::warn!("Failed to run command: {}", why);
+    }
 }
 
 pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {

--- a/ababot/bot/src/commands/ping.rs
+++ b/ababot/bot/src/commands/ping.rs
@@ -1,8 +1,7 @@
 use serenity::{
     builder::CreateApplicationCommand,
     model::prelude::interaction::{
-        application_command::{ApplicationCommandInteraction, CommandDataOption},
-        InteractionResponseType,
+        application_command::ApplicationCommandInteraction, InteractionResponseType,
     },
     prelude::Context,
 };

--- a/ababot/bot/src/commands/ping.rs
+++ b/ababot/bot/src/commands/ping.rs
@@ -1,10 +1,24 @@
 use serenity::{
     builder::CreateApplicationCommand,
-    model::prelude::interaction::application_command::CommandDataOption,
+    model::prelude::interaction::{
+        application_command::{ApplicationCommandInteraction, CommandDataOption},
+        InteractionResponseType,
+    },
+    prelude::Context,
 };
 
-pub async fn run(_options: &[CommandDataOption]) -> String {
-    "Pong!".to_string()
+pub async fn run(ctx: &Context, command: &ApplicationCommandInteraction) {
+    let pong = "Pong!".to_string();
+    if let Err(why) = command
+        .create_interaction_response(&ctx.http, |response| {
+            response
+                .kind(InteractionResponseType::ChannelMessageWithSource)
+                .interaction_response_data(|message| message.content(pong))
+        })
+        .await
+    {
+        tracing::warn!("Failed to run command: {}", why);
+    }
 }
 
 pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {

--- a/ababot/bot/src/commands/stonk.rs
+++ b/ababot/bot/src/commands/stonk.rs
@@ -4,8 +4,7 @@ use serenity::{
     model::prelude::{
         command::CommandOptionType,
         interaction::{
-            application_command::{ApplicationCommandInteraction, CommandDataOption},
-            InteractionResponseType,
+            application_command::ApplicationCommandInteraction, InteractionResponseType,
         },
     },
     prelude::Context,

--- a/ababot/bot/src/lib.rs
+++ b/ababot/bot/src/lib.rs
@@ -10,6 +10,8 @@ pub mod types;
 
 pub struct Handler;
 
+async fn nop() {}
+
 #[async_trait]
 impl EventHandler for Handler {
     async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
@@ -17,18 +19,18 @@ impl EventHandler for Handler {
             tracing::debug!("Received command interaction {:#?}", command);
 
             let input = command.data.name.as_str();
-            let content = dir_macros::run_commands_async!("bot/src/commands" "commands" "run(&command.data.options)");
+            dir_macros::run_commands_async!("bot/src/commands" "commands" "run(&ctx,&command)");
 
-            if let Err(why) = command
-                .create_interaction_response(&ctx.http, |response| {
-                    response
-                        .kind(InteractionResponseType::ChannelMessageWithSource)
-                        .interaction_response_data(|message| message.content(content))
-                })
-                .await
-            {
-                tracing::warn!("Failed to run command {}: {}", input, why);
-            }
+            // if let Err(why) = command
+            //     .create_interaction_response(&ctx.http, |response| {
+            //         response
+            //             .kind(InteractionResponseType::ChannelMessageWithSource)
+            //             .interaction_response_data(|message| message.content(content))
+            //     })
+            //     .await
+            // {
+            //     tracing::warn!("Failed to run command {}: {}", input, why);
+            // }
         }
     }
 

--- a/ababot/bot/src/lib.rs
+++ b/ababot/bot/src/lib.rs
@@ -20,17 +20,6 @@ impl EventHandler for Handler {
 
             let input = command.data.name.as_str();
             dir_macros::run_commands_async!("bot/src/commands" "commands" "run(&ctx,&command)");
-
-            // if let Err(why) = command
-            //     .create_interaction_response(&ctx.http, |response| {
-            //         response
-            //             .kind(InteractionResponseType::ChannelMessageWithSource)
-            //             .interaction_response_data(|message| message.content(content))
-            //     })
-            //     .await
-            // {
-            //     tracing::warn!("Failed to run command {}: {}", input, why);
-            // }
         }
     }
 

--- a/ababot/bot/src/lib.rs
+++ b/ababot/bot/src/lib.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use serenity::async_trait;
-use serenity::model::application::interaction::{Interaction, InteractionResponseType};
+use serenity::model::application::interaction::Interaction;
 use serenity::model::prelude::{GuildId, Ready};
 use serenity::prelude::{Context, EventHandler};
 

--- a/ababot/dir_macros/src/lib.rs
+++ b/ababot/dir_macros/src/lib.rs
@@ -92,7 +92,7 @@ pub fn run_commands_async(input: TokenStream) -> TokenStream {
             format!("{}.await", function_name.value())
         ))
     }
-    output.push_str("_ => \"Unrecognized command\".to_string()\n}");
+    output.push_str("_ => nop().await\n}");
 
     match output.parse() {
         Ok(tok_stream) => tok_stream,


### PR DESCRIPTION
Things to change before merge

- Re-enable feature. Dice will do nothing if feature not turned on. Most likely panic
- Remove dead code. Some comments used as refrence in migration process still in code

Not in the scope of this PR, but may be added

- Add single function that is responsible for simple string answers to reduced duped code
- Find a better way to pass variables in the macro. Is it possible to imitate println!("{}",arg) ?