### PR TITLE
Long running tasks moved to cache_ready

### DIFF
--- a/ababot/bot/src/lib.rs
+++ b/ababot/bot/src/lib.rs
@@ -29,14 +29,18 @@ impl EventHandler for Handler {
         }
     }
 
+    async fn cache_ready(&self, ctx: Context, _guilds: Vec<GuildId>) {
+        tracing::debug!("Cache ready");
+        let ctx = Arc::new(ctx);
+        dir_macros::long_running!("bot/src/background_tasks" "background_tasks" "run(ctx_cpy)");
+        tracing::info!("Background tasks started");
+        println!("Cache ready");
+    }
+
     #[instrument(skip(self, ctx, ready))]
     async fn ready(&self, ctx: Context, ready: Ready) {
         tracing::info!("Connecting as {}", ready.user.name);
 
-        // Check should not be neccessary as ready is only called once
-        let ctx = Arc::new(ctx);
-        // Every background task has to handle its own setup, executing, and contiguos execution
-        dir_macros::long_running!("bot/src/background_tasks" "background_tasks" "run(ctx_cpy)");
         let guild_id = GuildId(
             env::var("GUILD_ID")
                 .expect("Expected GUILD_ID in environment")


### PR DESCRIPTION
Moved long running tasks to cache_ready hoping it won't dispatch again on reconnect